### PR TITLE
Change all "resolve" and "OpenURL Resolver" references to "Ariadne"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-resolve
+ariadne

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-resolve
+ariadne
 coverage.out
 
 .vscode

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenURL Resolver
+# Ariadne
 
 ## Frontend
 
@@ -24,7 +24,7 @@ docker-compose up frontend
 
 ## Backend
 
-The OpenURL Resolver backend provides a simple JSON API written in Go that takes
+The Ariadne backend provides a simple JSON API written in Go that takes
 an [OpenURL](https://biblio.ugent.be/publication/760060/file/760063.pdf) and
 returns electronic links from an SFX Knowledgebase that represent NYU's
 e-holdings of the resource identified by the OpenURL. It is essentially an API
@@ -155,7 +155,7 @@ This is the existing SFX service response for The New Yorker:
 
 > http://sfx.library.nyu.edu/sfxlcl41?url_ver=Z39.88-2004&url_ctx_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Actx&ctx_ver=Z39.88-2004&ctx_tim=2021-10-22T12%3A29%3A27-04%3A00&ctx_id=&ctx_enc=info%3Aofi%2Fenc%3AUTF-8&rft.aulast=Ross&rft.date=2002&rft.eissn=2163-3827&rft.genre=journal&rft.issn=0028-792X&rft.jtitle=New+Yorker&rft.language=eng&rft.lccn=++2011201780&rft.object_id=110975413975944&rft.oclcnum=909782404&rft.place=New+York&rft.private_data=909782404%3Cfssessid%3E0%3C%2Ffssessid%3E&rft.pub=F-R+Pub.+Corp.&rft.stitle=NEW+YORKER&rft.title=New+Yorker&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&rft_id=info%3Aoclcnum%2F909782404&rft_id=urn%3AISSN%3A0028-792X&req.ip=209.150.44.95&rfr_id=info%3Asid%2FFirstSearch%3AWorldCat
 
-OpenURL Resolver should return the same set of links for use in the frontend:
+Ariadne should return the same set of links for use in the frontend:
 
 JSON:
 > http://localhost:8080/v0/?url_ver=Z39.88-2004&url_ctx_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Actx&ctx_ver=Z39.88-2004&ctx_tim=2021-10-22T12%3A29%3A27-04%3A00&ctx_id=&ctx_enc=info%3Aofi%2Fenc%3AUTF-8&rft.aulast=Ross&rft.date=2002&rft.eissn=2163-3827&rft.genre=journal&rft.issn=0028-792X&rft.jtitle=New+Yorker&rft.language=eng&rft.lccn=++2011201780&rft.object_id=110975413975944&rft.oclcnum=909782404&rft.place=New+York&rft.private_data=909782404%3Cfssessid%3E0%3C%2Ffssessid%3E&rft.pub=F-R+Pub.+Corp.&rft.stitle=NEW+YORKER&rft.title=New+Yorker&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&rft_id=info%3Aoclcnum%2F909782404&rft_id=urn%3AISSN%3A0028-792X&req.ip=209.150.44.95&rfr_id=info%3Asid%2FFirstSearch%3AWorldCat

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,8 +7,8 @@ RUN go mod tidy && \
     go build && \
     go clean -modcache
 
-FROM alpine:latest  
+FROM alpine:latest
 WORKDIR /app
 COPY --from=builder /app ./
 EXPOSE 8080
-CMD ["./resolve"]  
+CMD ["./ariadne"]

--- a/backend/Dockerfile.debug-and-test
+++ b/backend/Dockerfile.debug-and-test
@@ -16,7 +16,7 @@ WORKDIR /app
 COPY . .
 RUN go mod tidy && \
     go install -v ./... && \
-    go build -gcflags="all=-N -l" -o resolve && \
+    go build -gcflags="all=-N -l" -o ariadne && \
     go clean -modcache && \
     go install -v github.com/go-delve/delve/cmd/dlv@v1.9.0 && \
     mkdir tools && \

--- a/backend/api/response.go
+++ b/backend/api/response.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"resolve/sfx"
+	"ariadne/sfx"
 )
 
 type response struct {

--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -1,11 +1,11 @@
 package api
 
 import (
+	"ariadne/sfx"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
-	"resolve/sfx"
 )
 
 // Setup a new mux router with the appropriate routes for this app

--- a/backend/api/server_test.go
+++ b/backend/api/server_test.go
@@ -1,14 +1,14 @@
 package api
 
 import (
+	"ariadne/sfx"
+	"ariadne/util"
 	"flag"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"resolve/sfx"
-	"resolve/util"
 	"testing"
 )
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,3 @@
-module resolve
+module ariadne
 
 go 1.17

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"ariadne/api"
 	"log"
 	"net/http"
-	"resolve/api"
 )
 
 // Run on port 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: "3.9"
 
 x-build-frontend: &x-build-frontend
-  image: resolve-frontend
+  image: ariadne-frontend
   build:
     context: frontend/
     cache_from:
-      - resolve-frontend
+      - ariadne-frontend
   networks:
-    - resolve-net
+    - ariadne-net
   depends_on:
     - backend
 
@@ -48,14 +48,14 @@ services:
     ports:
       - "8080:8080"
     networks:
-      - resolve-net
+      - ariadne-net
     # <<: *x-development-volumes-backend
 
   backend-debug:
     <<: *x-build-backend-test
     # Dockerfile.debug-and-test is primarily a test container.  We need to override
     # the `go test...` CMD, running delve instead.
-    command: [ "./tools/dlv", "--listen=:2345", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "./resolve" ]
+    command: [ "./tools/dlv", "--listen=:2345", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "./ariadne" ]
     cap_add:
       - SYS_PTRACE
     ports:
@@ -64,7 +64,7 @@ services:
       # Application port
       - "8080:8080"
     networks:
-      - resolve-net
+      - ariadne-net
     security_opt:
       - apparmor:unconfined
     # <<: *x-development-volumes-backend
@@ -86,5 +86,5 @@ services:
     # <<: *x-development-volumes-backend
 
 networks:
-  resolve-net:
+  ariadne-net:
     driver: bridge

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Resolver</title>
+    <title>Ariadne</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Project has been renamed from "resolve" to "ariadne".  This PR updates all internal references.