### PR TITLE
Replace axios with native fetch

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "axios": "^0.27.2",
     "bootstrap": "^5.2.1",
     "dotenv": "^16.0.3",
     "react": "^18.2.0",

--- a/frontend/src/api/apiClient.js
+++ b/frontend/src/api/apiClient.js
@@ -1,9 +1,8 @@
 const apiClient = {
   get: async function get(path) {
     const url = `${process.env.REACT_APP_API_URL}${path}`;
-    const response = await fetch(url);
 
-    return response.json();
+    return await fetch(url);
   },
 };
 

--- a/frontend/src/api/apiClient.js
+++ b/frontend/src/api/apiClient.js
@@ -1,7 +1,10 @@
-import axios from 'axios';
+const apiClient = {
+  get: async function get(path) {
+    const url = `${process.env.REACT_APP_API_URL}${path}`;
+    const response = await fetch(url);
 
-const apiClient = axios.create({
-  baseURL: process.env.REACT_APP_API_URL,
-});
+    return response.json();
+  },
+};
 
 export default apiClient;

--- a/frontend/src/api/fetchData.js
+++ b/frontend/src/api/fetchData.js
@@ -1,5 +1,5 @@
 import apiClient from './apiClient';
 
-const fetchData = () => apiClient.get('/' + window.location.search);
+const fetchData = () => apiClient.get(window.location.search);
 
 export default { fetchData };

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -11,7 +11,7 @@ export default (apiFunc) => {
     setLoading(true);
     try {
       const response = await apiFunc(...args);
-      const arrOfLinks = getLinks(response.data.records);
+      const arrOfLinks = getLinks(response.records);
       setResource(arrOfLinks.slice(0, -1));
       setResourceLastElement(arrOfLinks.at(-1));
     } catch (error) {

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -11,7 +11,8 @@ export default (apiFunc) => {
     setLoading(true);
     try {
       const response = await apiFunc(...args);
-      const arrOfLinks = getLinks(response.records);
+      const responseBody = await response.json();
+      const arrOfLinks = getLinks(responseBody.records);
       setResource(arrOfLinks.slice(0, -1));
       setResourceLastElement(arrOfLinks.at(-1));
     } catch (error) {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2680,14 +2680,6 @@ axe-core@^4.4.3:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.3.tgz#11c74d23d5013c0fa5d183796729bc3482bd2f6f"
   integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
 
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
-  dependencies:
-    follow-redirects "^1.14.9"
-    form-data "^4.0.0"
-
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -4495,11 +4487,6 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
-follow-redirects@^1.14.9:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
-  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
-
 fork-ts-checker-webpack-plugin@^6.5.0:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.2.tgz#4f67183f2f9eb8ba7df7177ce3cf3e75cdafb340"
@@ -4523,15 +4510,6 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"


### PR DESCRIPTION
Replace axios with native `fetch` for simplicity and to make it easier to get the HTTP status code and message for the response.  This PR changes the return value for `apiClient.get` from a JSON object to a JS native [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) to server the latter purpose.  We could also extract the `status` and `statusText` fields from the `Response` object and wrap them in our own custom JSON response, but since `Response` is native and unlikely to ever change much in a way that breaks backward compatibility, returning it to client code would seem to be reasonable thing to do.