### PR TITLE
Standardize on ESM when possible

### DIFF
--- a/frontend/src/testutils/index.js
+++ b/frontend/src/testutils/index.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+import * as fs from 'node:fs';
 const path = require('path');
 
 // Prefer actual backend/api/testdata/ files if they exist (i.e. running tests on


### PR DESCRIPTION
Since most of `frontend/` is already using ESM (`import`) rather than CommonJS (`require`), for the sake of consistency and and since ESM is JavaScript native and likely the future of modules, standardize on ECMAScript modules when possible.

`require`'s were changed to `import`'s except in the following cases:

* `path`: judging by the documentation for [path](https://nodejs.org/api/path.html) for Node v.19.1.0, currently only available as a CommonJS module.
* `@playwright/test`: judging by the [Playwright Test](https://playwright.dev/docs/api/class-test) API documentation, currently only available as a CommonJS module.
* `require`'s that are used to read in JSON files, not JS modules.

See https://nodejs.org/api/esm.html for more details on Node-specific ESM.
