### PR TITLE
Remove Ask a Librarian target from backend response

### DIFF
--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -53,6 +53,10 @@ func multipleRecordsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Remove the Ask a Librarian target -- for details, see:
+	// https://nyu-lib.monday.com/boards/765008773/pulses/3548498827
+	sfxResponse.RemoveTarget("http://library.nyu.edu/ask/")
+
 	ariadneResponse := response{
 		Errors:  []string{},
 		Records: sfxResponse.MultiObjXMLResponseBody,

--- a/backend/api/testdata/server/golden/corriere-fiorentino.json
+++ b/backend/api/testdata/server/golden/corriere-fiorentino.json
@@ -33,28 +33,6 @@
                                         }
                                     }
                                 ]
-                            },
-                            {
-                                "target_name": "ASK_A_LIBRARIAN_LCL",
-                                "target_public_name": "Ask a Librarian",
-                                "target_url": "http://library.nyu.edu/ask/",
-                                "authentication": "",
-                                "proxy": "no",
-                                "coverage": [
-                                    {
-                                        "coverage_text": [
-                                            {
-                                                "threshold_text": [
-                                                    {}
-                                                ],
-                                                "embargo_text": [
-                                                    {}
-                                                ]
-                                            }
-                                        ],
-                                        "embargo": {}
-                                    }
-                                ]
                             }
                         ]
                     }

--- a/backend/api/testdata/server/golden/the-new-yorker.json
+++ b/backend/api/testdata/server/golden/the-new-yorker.json
@@ -442,28 +442,6 @@
                                         "embargo": {}
                                     }
                                 ]
-                            },
-                            {
-                                "target_name": "ASK_A_LIBRARIAN_LCL",
-                                "target_public_name": "Ask a Librarian",
-                                "target_url": "http://library.nyu.edu/ask/",
-                                "authentication": "",
-                                "proxy": "no",
-                                "coverage": [
-                                    {
-                                        "coverage_text": [
-                                            {
-                                                "threshold_text": [
-                                                    {}
-                                                ],
-                                                "embargo_text": [
-                                                    {}
-                                                ]
-                                            }
-                                        ],
-                                        "embargo": {}
-                                    }
-                                ]
                             }
                         ]
                     }

--- a/backend/sfx/response.go
+++ b/backend/sfx/response.go
@@ -95,6 +95,17 @@ type ThresholdText struct {
 	CoverageStatement []string `xml:"coverage_statement" json:"coverage_statement,omitempty"`
 }
 
+func (multipleObjectsResponse *MultipleObjectsResponse) RemoveTarget(targetURL string) {
+	currentTargets := (*(*multipleObjectsResponse.MultiObjXMLResponseBody.ContextObject)[0].SFXContextObjectTargets)[0].Targets
+	var newTargets []Target
+	for _, target := range *currentTargets {
+		if target.TargetUrl != targetURL {
+			newTargets = append(newTargets, target)
+		}
+	}
+	(*(*multipleObjectsResponse.MultiObjXMLResponseBody.ContextObject)[0].SFXContextObjectTargets)[0].Targets = &newTargets
+}
+
 func newMultipleObjectsResponse(httpResponse *http.Response) (*MultipleObjectsResponse, error) {
 	// NOTE: `defer httpResponse.Body.Close()` should have already been called by the client
 	// before passing to this function.

--- a/frontend/src/components/List/List.test.js
+++ b/frontend/src/components/List/List.test.js
@@ -91,7 +91,10 @@ describe('Backend success', () => {
       await waitForElementToBeRemoved(() => getByText(LOADING_TEXT_REGEXP));
     });
 
-    test('renders correctly', async () => {
+    // TODO: Re-enable this test after Ask a Librarian changes have been made
+    // in the frontend:
+    // https://nyu-lib.monday.com/boards/765008773/pulses/3548498827/posts/1845149349
+    test.skip('renders correctly', async () => {
       const actual = render(<List />);
       await waitForElementToBeRemoved(() => screen.getByText(LOADING_TEXT_REGEXP));
       expect(actual.asFragment()).toMatchSnapshot();
@@ -111,7 +114,10 @@ describe('Backend success', () => {
       expect(container.getElementsByClassName('list-group').length).toBe(1);
     });
 
-    test('renders Ask a Librarian', async () => {
+    // TODO: Re-enable this test after Ask a Librarian changes have been made
+    // in the frontend:
+    // https://nyu-lib.monday.com/boards/765008773/pulses/3548498827/posts/1845149349
+    test.skip('renders Ask a Librarian', async () => {
       render(<List />);
       // See comment at top of file: 'Clearing "wrap in act()" warnings'
       await waitForElementToBeRemoved(() => screen.getByText(LOADING_TEXT_REGEXP));


### PR DESCRIPTION
monday.com: [Remove Ask\-a\-Librarian from backend](https://nyu-lib.monday.com/boards/765008773/pulses/3548498827)

NOTE: This PR disables tests that broke after this backend change was made.  They will be restored in the [Add Ask\-a\-Librarian link to right side bar](https://nyu-lib.monday.com/boards/765008773/pulses/3586482699) PR to follow.