### PR TITLE
Fix backend marshaling error response

### DIFF
--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -63,11 +63,28 @@ func multipleRecordsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	responseJSON, err := json.MarshalIndent(ariadneResponse, "", "    ")
+	// Very unlikely that this will error out.  At the moment, can't even think
+	// of a way to force an error so that can write a test.  Tested this error handling
+	// code during development by setting `err = errors.New("error!")` right after marshalling.
+	// Result:
+	// {
+	//     "errors": [
+	//         "Could not marshal ariadne response to JSON: error!"
+	//     ],
+	//     "records": {
+	//         "ctx_obj": null
+	//     }
+	// }
 	if err != nil {
 		ariadneResponse = Response{
-			Errors:  []string{fmt.Sprintf("could not marshal ariadne response to JSON: %v", err)},
+			Errors:  []string{fmt.Sprintf("Could not marshal ariadne response to JSON: %v", err)},
 			Records: sfx.MultiObjXMLResponseBody{},
 		}
+
+		// Even more unlikely that this marshalling will error out, but if it does
+		// just let the chips fall.  The frontend will report the error to receive
+		// an intelligible response from the backend API.
+		responseJSON, _ = json.MarshalIndent(ariadneResponse, "", "    ")
 	}
 
 	fmt.Fprintln(w, string(responseJSON))


### PR DESCRIPTION
backend/api/server.go: have the error handling for failure to marshal `ariadneResponse` return an error response.