### PR TITLE
backend/: change `sfx.NewSFXRequest` param from `queryStringValues url.Values` to `queryString string`

### DIFF
--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -24,7 +24,7 @@ func ResolverHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Add("Content-Type", "application/json")
 
-	sfxRequest, err := sfx.NewSFXRequest(r.URL.Query())
+	sfxRequest, err := sfx.NewSFXRequest(r.URL.RawQuery)
 	if err != nil {
 		handleError(err, w, "Invalid OpenURL")
 		return

--- a/backend/cmd/debug/sfx.go
+++ b/backend/cmd/debug/sfx.go
@@ -3,7 +3,6 @@ package debug
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"net/url"
 
 	"ariadne/sfx"
 )
@@ -46,12 +45,7 @@ var dumpSFXHTTPResponseCmd = &cobra.Command{
 }
 
 func dumpSFXHTTPRequest(queryString string) (string, error) {
-	urlValues, err := url.ParseQuery(queryString)
-	if err != nil {
-		return queryString, err
-	}
-
-	sfxRequest, err := sfx.NewSFXRequest(urlValues)
+	sfxRequest, err := sfx.NewSFXRequest(queryString)
 	if err != nil {
 		return queryString, err
 	}
@@ -60,12 +54,7 @@ func dumpSFXHTTPRequest(queryString string) (string, error) {
 }
 
 func dumpSFXHTTPResponse(queryString string) (string, error) {
-	urlValues, err := url.ParseQuery(queryString)
-	if err != nil {
-		return queryString, err
-	}
-
-	sfxRequest, err := sfx.NewSFXRequest(urlValues)
+	sfxRequest, err := sfx.NewSFXRequest(queryString)
 	if err != nil {
 		return queryString, err
 	}

--- a/backend/sfx/request.go
+++ b/backend/sfx/request.go
@@ -29,8 +29,13 @@ func (c SFXRequest) do() (*SFXResponse, error) {
 	return sfxResponse, nil
 }
 
-func NewSFXRequest(queryStringValues url.Values) (*SFXRequest, error) {
+func NewSFXRequest(queryString string) (*SFXRequest, error) {
 	sfxRequest := &SFXRequest{}
+
+	queryStringValues, err := url.ParseQuery(queryString)
+	if err != nil {
+		return sfxRequest, err
+	}
 
 	httpRequest, err := newSFXHTTPRequest(queryStringValues)
 	if err != nil {

--- a/backend/sfx/request_test.go
+++ b/backend/sfx/request_test.go
@@ -14,7 +14,7 @@ func TestNewSFXRequest(t *testing.T) {
 		name              string
 		dumpedHTTPRequest string
 		expectedError     error
-		queryStringValues url.Values
+		queryString       string
 	}{
 		{
 			// This request as-is was causing SFX to return a "XSS violation occured [sic]."
@@ -24,47 +24,10 @@ func TestNewSFXRequest(t *testing.T) {
 			// NOTE: This is the can-community-task-groups-learn-from-the-principles-of-group-therapy
 			// test case from backend/api/testdata/server/test-cases.json.
 			name: "Trouble-causing `sid`",
-			dumpedHTTPRequest: `GET /sfxlcl41?atitle=Can+community+task+groups+learn+from+the+principles+of+group+therapy%3F&aulast=Zanbar%2C+L.&date=20181020&genre=article&isbn=&issn=19447485&issue=5&pid=Zanbar%2C+L.edselc.2-52.0-8505573399120181020Scopus%5C%5Cu00ae&rfr_id=EBSCO%3AScopus%5C%5Cu00ae&sfx.doi_url=http%3A%2F%2Fdx.doi.org&sfx.response_type=multi_obj_xml&spage=574&title=Community+Development&url_ctx_fmt=info%3Aofi%2Ffmt%3Axml%3Axsd%3Actx&volume=49 HTTP/1.1
+			dumpedHTTPRequest: `GET /sfxlcl41?atitle=Can+community+task+groups+learn+from+the+principles+of+group+therapy%3F&aulast=Zanbar%2C+L.&date=20181020&genre=article&isbn=&issn=19447485&issue=5&pid=Zanbar%2C+L.edselc.2-52.0-8505573399120181020Scopus%5C%C2%AE&rfr_id=EBSCO%3AScopus%5C%C2%AE&sfx.doi_url=http%3A%2F%2Fdx.doi.org&sfx.response_type=multi_obj_xml&spage=574&title=Community+Development&url_ctx_fmt=info%3Aofi%2Ffmt%3Axml%3Axsd%3Actx&volume=49 HTTP/1.1
 Host: sfx.library.nyu.edu`,
 			expectedError: nil,
-			queryStringValues: map[string][]string{
-				"atitle": {
-					"Can community task groups learn from the principles of group therapy?",
-				},
-				"aulast": {
-					"Zanbar, L.",
-				},
-				"date": {
-					"20181020",
-				},
-				"genre": {
-					"article",
-				},
-				"isbn": {
-					"",
-				},
-				"issn": {
-					"19447485",
-				},
-				"issue": {
-					"5",
-				},
-				"pid": {
-					"Zanbar, L.edselc.2-52.0-8505573399120181020Scopus\\\\u00ae",
-				},
-				"sid": {
-					"EBSCO:Scopus\\\\u00ae",
-				},
-				"spage": {
-					"574",
-				},
-				"title": {
-					"Community Development",
-				},
-				"volume": {
-					"49",
-				},
-			},
+			queryString:   "genre=article&isbn=&issn=19447485&title=Community%20Development&volume=49&issue=5&date=20181020&atitle=Can%20community%20task%20groups%20learn%20from%20the%20principles%20of%20group%20therapy?&aulast=Zanbar,%20L.&spage=574&sid=EBSCO:Scopus\\®&pid=Zanbar,%20L.edselc.2-52.0-8505573399120181020Scopus\\®",
 		},
 		// These unit tests were originally written when Ariadne was making POST
 		// requests to the SFX API, with complicated query string params validation
@@ -83,9 +46,9 @@ Host: sfx.library.nyu.edu`,
 	}
 
 	for _, testCase := range tests {
-		testName := fmt.Sprintf("%s", testCase.queryStringValues)
+		testName := fmt.Sprintf("%s", testCase.queryString)
 		t.Run(testName, func(t *testing.T) {
-			sfxRequest, err := NewSFXRequest(testCase.queryStringValues)
+			sfxRequest, err := NewSFXRequest(testCase.queryString)
 			if testCase.dumpedHTTPRequest != "" {
 				expected := normalizeDumpedHTTPRequest(testCase.dumpedHTTPRequest)
 				got := normalizeDumpedHTTPRequest(sfxRequest.DumpedHTTPRequest)


### PR DESCRIPTION
Make `sfx.NewSFXRequest` simpler and more versatile by changing its param from `url.Values` to `string` (`url.RawQuery`).  There were a multiple clients of this method that had to do `url.ParseQuery` (either directly or indirectly -- e.g. `r.URL.Query()`) which seemed like indicate unnecessary burden on the caller.  Unit tests for `sfx.NewSFXRequest` were also a bit awkward as they required hardcoding `map[string][]string` values for each test case.  Using query strings is a lot easier, and also makes query parsing more consistent as it happens only in one place now.
