### PR TITLE
Clear `gofmt` diff; enable `found` at top-level of response; re-enable `gofmt` check in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,38 +122,27 @@ jobs:
           name: Build backend-test service
           command: |
             docker-compose build backend-test
-#          Disabling `gofmt` checks for now, as `gofmt` in CircleCI is yielding different
-#          results than `gofmt` on local, and also appears to be erroneously
-#          reporting non-existent differences.  NOTE: The "^@" issue referred to
-#          in the command comments has already been resolved.  The examples below
-#          are due to different causes.
-#
-#          Examples:
-#             * Commit that fixes false positive: https://github.com/NYULibraries/ariadne/commit/bc07fb2b9cac82916d83c39506d30868b1f244a3
-#             * Most recent failed CircleCI job due to another apparent false positive (local `gofmt` yields no output):
-#               https://app.circleci.com/pipelines/github/NYULibraries/ariadne/581/workflows/25cd608c-686d-45ed-ade1-3730ccf058e9/jobs/2377
-#
-#      - run:
-#          name: Check formatting
-#          command: |
-#            gofmt_result="$( docker-compose run backend-test /bin/bash -c 'export APP_PATH=/app/; if [[ ! -z $( find $APP_PATH -name "*.go\
-#            " ) ]]; then gofmt -l $APP_PATH; else echo >&2 "No *.go files found in path: $APP_PATH"; fi' )"
-#
-#            # Even if `gofmt -l $APP_PATH` returns no paths, there still seem to
-#            # be some non-printing characters in `gofmt_result` (in CircleCI output,
-#            # they appear as "^@" characters), so instead of doing a `test -z` test,
-#            # simply check for the presence of alphanumeric characters, which
-#            # would only be present in the output if `gofmt` returned paths or
-#            # if an error occurred.
-#            if [[ "$gofmt_result" =~ [[:alnum:]] ]]
-#            then
-#                echo -e "\n\ngofmt check fail:\n$gofmt_result"
-#                exit_status=1
-#            else
-#                exit_status=0
-#            fi
-#
-#            exit $exit_status
+      - run:
+          name: Check formatting
+          command: |
+            gofmt_result="$( docker-compose run backend-test /bin/bash -c 'export APP_PATH=/app/; if [[ ! -z $( find $APP_PATH -name "*.go\
+            " ) ]]; then gofmt -l $APP_PATH; else echo >&2 "No *.go files found in path: $APP_PATH"; fi' )"
+
+            # Even if `gofmt -l $APP_PATH` returns no paths, there still seem to
+            # be some non-printing characters in `gofmt_result` (in CircleCI output,
+            # they appear as "^@" characters), so instead of doing a `test -z` test,
+            # simply check for the presence of alphanumeric characters, which
+            # would only be present in the output if `gofmt` returned paths or
+            # if an error occurred.
+            if [[ "$gofmt_result" =~ [[:alnum:]] ]]
+            then
+                echo -e "\n\ngofmt check fail:\n$gofmt_result"
+                exit_status=1
+            else
+                exit_status=0
+            fi
+
+            exit $exit_status
       - run:
           name: Run tests
           command: |

--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -24,7 +24,6 @@ func NewRouter() *http.ServeMux {
 func ResolverHandler(w http.ResponseWriter, r *http.Request) {
 	setHeaders(&w)
 
-
 	sfxResponse, err := getSFXResponse(r.URL.RawQuery)
 	if err != nil {
 		handleError(err, w, err.Error())

--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -99,11 +99,8 @@ func makeJSONResponseFromSFXResponse(sfxResponse *sfx.SFXResponse) []byte {
 	}
 
 	ariadneResponse := Response{
-		Errors: []string{},
-		// Hardcoding `false` for now.  This is just a placeholder for the value
-		// that will be calculated according to https://nyu-lib.monday.com/boards/765008773/pulses/4116986234?userId=27226106
-		// acceptance criteria.
-		Found:   false,
+		Errors:  []string{},
+		Found:   sfxResponse.IsFound(),
 		Records: records,
 	}
 

--- a/backend/testutils/testdata/golden/can-community-task-groups-learn-from-the-principles-of-group-therapy.json
+++ b/backend/testutils/testdata/golden/can-community-task-groups-learn-from-the-principles-of-group-therapy.json
@@ -1,6 +1,6 @@
 {
     "errors": [],
-    "found": false,
+    "found": true,
     "records": [
         {
             "citation_supplemental": {},

--- a/backend/testutils/testdata/golden/corriere-fiorentino.json
+++ b/backend/testutils/testdata/golden/corriere-fiorentino.json
@@ -1,6 +1,6 @@
 {
     "errors": [],
-    "found": false,
+    "found": true,
     "records": [
         {
             "citation_supplemental": {},

--- a/backend/testutils/testdata/golden/design-of-led-light-therapy-device-based-on-free-form-lens.json
+++ b/backend/testutils/testdata/golden/design-of-led-light-therapy-device-based-on-free-form-lens.json
@@ -1,6 +1,6 @@
 {
     "errors": [],
-    "found": false,
+    "found": true,
     "records": [
         {
             "citation_supplemental": {},

--- a/backend/testutils/testdata/golden/editorial-cartoon.json
+++ b/backend/testutils/testdata/golden/editorial-cartoon.json
@@ -1,6 +1,6 @@
 {
     "errors": [],
-    "found": false,
+    "found": true,
     "records": [
         {
             "citation_supplemental": {},

--- a/backend/testutils/testdata/golden/history-today.json
+++ b/backend/testutils/testdata/golden/history-today.json
@@ -1,6 +1,6 @@
 {
     "errors": [],
-    "found": false,
+    "found": true,
     "records": [
         {
             "citation_supplemental": {},

--- a/backend/testutils/testdata/golden/life-magazine-and-the-power-of-photography.json
+++ b/backend/testutils/testdata/golden/life-magazine-and-the-power-of-photography.json
@@ -1,6 +1,6 @@
 {
     "errors": [],
-    "found": false,
+    "found": true,
     "records": [
         {
             "citation_supplemental": {},

--- a/backend/testutils/testdata/golden/modelling-modular-living.json
+++ b/backend/testutils/testdata/golden/modelling-modular-living.json
@@ -1,6 +1,6 @@
 {
     "errors": [],
-    "found": false,
+    "found": true,
     "records": [
         {
             "citation_supplemental": {},

--- a/backend/testutils/testdata/golden/moral-psychology-is-relationship-regulation.json
+++ b/backend/testutils/testdata/golden/moral-psychology-is-relationship-regulation.json
@@ -1,6 +1,6 @@
 {
     "errors": [],
-    "found": false,
+    "found": true,
     "records": [
         {
             "citation_supplemental": {},

--- a/backend/testutils/testdata/golden/publish-the-picture-at-your-peril.json
+++ b/backend/testutils/testdata/golden/publish-the-picture-at-your-peril.json
@@ -1,6 +1,6 @@
 {
     "errors": [],
-    "found": false,
+    "found": true,
     "records": [
         {
             "citation_supplemental": {},

--- a/backend/testutils/testdata/golden/publish-the-picture-at-your-peril_unescaped-ampersand.json
+++ b/backend/testutils/testdata/golden/publish-the-picture-at-your-peril_unescaped-ampersand.json
@@ -1,6 +1,6 @@
 {
     "errors": [],
-    "found": false,
+    "found": true,
     "records": [
         {
             "citation_supplemental": {},

--- a/backend/testutils/testdata/golden/the-new-yorker.json
+++ b/backend/testutils/testdata/golden/the-new-yorker.json
@@ -1,6 +1,6 @@
 {
     "errors": [],
-    "found": false,
+    "found": true,
     "records": [
         {
             "citation_supplemental": {},

--- a/backend/testutils/testdata/golden/the-years-work-in-modern-language-studies.json
+++ b/backend/testutils/testdata/golden/the-years-work-in-modern-language-studies.json
@@ -1,6 +1,6 @@
 {
     "errors": [],
-    "found": false,
+    "found": true,
     "records": [
         {
             "citation_supplemental": {},


### PR DESCRIPTION
- Re-enabled `gofmt` check in CircleCI as it might not have been a false positive after all
- Enable `found` at top level of backend/
- Clear the `gofmt` diff in _server.go_