### PR TITLE
Error logging improvements

### DIFF
--- a/backend/primo/request.go
+++ b/backend/primo/request.go
@@ -26,13 +26,13 @@ func (primoRequest PrimoRequest) do() (*PrimoResponse, error) {
 	client := http.Client{}
 	httpResponse, err := client.Do(&primoRequest.ISBNSearchHTTPRequest)
 	if err != nil {
-		return &PrimoResponse{}, fmt.Errorf("could not do request to Primo server: %v", err)
+		return &PrimoResponse{}, fmt.Errorf("Could not do request to Primo server: %v", err)
 	}
 	defer httpResponse.Body.Close()
 
 	isbnSearchResponse, err := primoResponse.addHTTPResponseData(httpResponse)
 	if err != nil {
-		return primoResponse, fmt.Errorf("error adding to Primo response: %v", err)
+		return primoResponse, fmt.Errorf("Error adding to Primo response: %v", err)
 	}
 
 	isbn := getISBN(primoRequest.QueryStringValues)
@@ -59,7 +59,7 @@ func NewPrimoRequest(queryString string) (*PrimoRequest, error) {
 
 	httpRequest, err := newPrimoISBNSearchHTTPRequest(queryStringValues)
 	if err != nil {
-		return primoRequest, fmt.Errorf("could not create new Primo request: %v", err)
+		return primoRequest, fmt.Errorf("Could not create new Primo request: %v", err)
 	}
 	// NOTE: This appears to drain httpRequest.Body, so when getting the dumped
 	// HTTP request later, make sure to get it from primoRequest.ISBNSearchHTTPRequest
@@ -133,7 +133,7 @@ func newPrimoHTTPRequest(isbn string, frbrGroupID *string) (*http.Request, error
 
 	request, err := http.NewRequest("GET", queryURL, nil)
 	if err != nil {
-		return request, fmt.Errorf("could not initialize request to Primo server: %v", err)
+		return request, fmt.Errorf("Could not initialize request to Primo server: %v", err)
 	}
 
 	return request, nil

--- a/backend/primo/request_test.go
+++ b/backend/primo/request_test.go
@@ -47,7 +47,7 @@ Host: bobcat.library.nyu.edu`,
 	{
 		name:                                "Query string without `isbn` param",
 		expectedDumpedISBNSearchHTTPRequest: "",
-		expectedError:                       errors.New("could not create new Primo request: query string params do not contain required ISBN param"),
+		expectedError:                       errors.New("Could not create new Primo request: query string params do not contain required ISBN param"),
 		expectedQueryStringValues: url.Values{
 			"param1": {"1"},
 			"param2": {"2"},
@@ -58,7 +58,7 @@ Host: bobcat.library.nyu.edu`,
 	{
 		name:                                "Empty query string",
 		expectedDumpedISBNSearchHTTPRequest: "",
-		expectedError:                       errors.New("could not create new Primo request: query string params do not contain required ISBN param"),
+		expectedError:                       errors.New("Could not create new Primo request: query string params do not contain required ISBN param"),
 		expectedQueryStringValues:           url.Values{},
 		queryString:                         "",
 	},

--- a/backend/primo/response.go
+++ b/backend/primo/response.go
@@ -65,14 +65,14 @@ func (primoResponse *PrimoResponse) addHTTPResponseData(httpResponse *http.Respo
 
 	dumpedHTTPResponse, err := httputil.DumpResponse(httpResponse, true)
 	if err != nil {
-		return APIResponse{}, fmt.Errorf("could not dump HTTP response")
+		return APIResponse{}, fmt.Errorf("Could not dump HTTP response")
 	}
 
 	primoResponse.DumpedHTTPResponses = append(primoResponse.DumpedHTTPResponses, string(dumpedHTTPResponse))
 
 	body, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
-		return APIResponse{}, fmt.Errorf("could not read response from Primo server: %v", err)
+		return APIResponse{}, fmt.Errorf("Could not read response from Primo server: %v", err)
 	}
 
 	var apiResponse APIResponse
@@ -120,7 +120,7 @@ func (primoResponse *PrimoResponse) getDocsForFRBRGroup(isbn, frbrGroupID string
 
 	httpRequest, err := newPrimoHTTPRequest(isbn, &frbrGroupID)
 	if err != nil {
-		return docs, fmt.Errorf("could not create new FRBR group Primo request: %v", err)
+		return docs, fmt.Errorf("Could not create new FRBR group Primo request: %v", err)
 	}
 
 	// NOTE: This appears to drain httpRequest.Body, but currently these requests
@@ -138,13 +138,13 @@ func (primoResponse *PrimoResponse) getDocsForFRBRGroup(isbn, frbrGroupID string
 	client := http.Client{}
 	httpResponse, err := client.Do(httpRequest)
 	if err != nil {
-		return docs, fmt.Errorf("could not do FRBR group request to Primo server: %v", err)
+		return docs, fmt.Errorf("Could not do FRBR group request to Primo server: %v", err)
 	}
 	defer httpResponse.Body.Close()
 
 	apiResponse, err := primoResponse.addHTTPResponseData(httpResponse)
 	if err != nil {
-		return docs, fmt.Errorf("error adding to Primo response: %v", err)
+		return docs, fmt.Errorf("Error adding to Primo response: %v", err)
 	}
 
 	return apiResponse.Docs, nil
@@ -158,7 +158,7 @@ func (primoResponse *PrimoResponse) getLinks(isbn string, isbnSearchResponse API
 			docsForFRBRGroup, err :=
 				primoResponse.getDocsForFRBRGroup(isbn, doc.PNX.Facets.FRBRGroupID[0])
 			if err != nil {
-				return fmt.Errorf("error fetching FRBR group links: %v", err)
+				return fmt.Errorf("Error fetching FRBR group links: %v", err)
 			}
 			// Only collect links from docs that match the user-specified ISBN.
 			for _, frbrGroupDoc := range docsForFRBRGroup {

--- a/backend/sfx/request.go
+++ b/backend/sfx/request.go
@@ -17,7 +17,7 @@ func (c SFXRequest) do() (*SFXResponse, error) {
 	client := http.Client{}
 	response, err := client.Do(&c.HTTPRequest)
 	if err != nil {
-		return &SFXResponse{}, fmt.Errorf("could not do request to SFX server: %v", err)
+		return &SFXResponse{}, fmt.Errorf("Could not do request to SFX server: %v", err)
 	}
 	defer response.Body.Close()
 
@@ -39,7 +39,7 @@ func NewSFXRequest(queryString string) (*SFXRequest, error) {
 
 	httpRequest, err := newSFXHTTPRequest(queryStringValues)
 	if err != nil {
-		return sfxRequest, fmt.Errorf("could not create new SFX request: %v", err)
+		return sfxRequest, fmt.Errorf("Could not create new SFX request: %v", err)
 	}
 	// NOTE: This appears to drain httpRequest.Body, so when getting the dumped
 	// HTTP request later, make sure to get it from sfxRequest.HTTPRequest
@@ -100,7 +100,7 @@ func newSFXHTTPRequest(queryStringValues url.Values) (*http.Request, error) {
 	queryURL := sfxURL + "?" + params.Encode()
 	request, err := http.NewRequest("GET", queryURL, nil)
 	if err != nil {
-		return request, fmt.Errorf("could not initialize request to SFX server: %v", err)
+		return request, fmt.Errorf("Could not initialize request to SFX server: %v", err)
 	}
 
 	return request, nil

--- a/backend/sfx/response.go
+++ b/backend/sfx/response.go
@@ -171,7 +171,7 @@ func newSFXResponse(httpResponse *http.Response) (*SFXResponse, error) {
 	}
 
 	if xmlResponseBody.ContextObject == nil {
-		return sfxResponse, fmt.Errorf("could not identify context object in response")
+		return sfxResponse, fmt.Errorf("could not identify context object in response XML: %s", sfxResponse.XML)
 	}
 
 	sfxResponse.XMLResponseBody = xmlResponseBody

--- a/backend/sfx/response.go
+++ b/backend/sfx/response.go
@@ -154,13 +154,13 @@ func newSFXResponse(httpResponse *http.Response) (*SFXResponse, error) {
 
 	dumpedHTTPResponse, err := httputil.DumpResponse(httpResponse, true)
 	if err != nil {
-		return sfxResponse, fmt.Errorf("could not dump HTTP response")
+		return sfxResponse, fmt.Errorf("Could not dump HTTP response: %v", err)
 	}
 	sfxResponse.DumpedHTTPResponse = string(dumpedHTTPResponse)
 
 	body, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
-		return sfxResponse, fmt.Errorf("could not read response from SFX server: %v", err)
+		return sfxResponse, fmt.Errorf("Could not read response from SFX server: %v", err)
 	}
 
 	sfxResponse.XML = string(body)
@@ -171,14 +171,14 @@ func newSFXResponse(httpResponse *http.Response) (*SFXResponse, error) {
 	}
 
 	if xmlResponseBody.ContextObject == nil {
-		return sfxResponse, fmt.Errorf("could not identify context object in response XML: %s", sfxResponse.XML)
+		return sfxResponse, fmt.Errorf("Could not identify context object in response XML: %s", sfxResponse.XML)
 	}
 
 	sfxResponse.XMLResponseBody = xmlResponseBody
 
 	json, err := json.MarshalIndent(xmlResponseBody, "", "    ")
 	if err != nil {
-		return sfxResponse, fmt.Errorf("could not marshal SFX response body to JSON: %v", err)
+		return sfxResponse, fmt.Errorf("Could not marshal SFX response body to JSON: %v", err)
 	}
 
 	sfxResponse.JSON = string(json)

--- a/backend/sfx/response_test.go
+++ b/backend/sfx/response_test.go
@@ -61,7 +61,7 @@ func TestNewSFXResponse(t *testing.T) {
 	}{
 		{"Good SFX response", makeFakeHTTPResponse(dummyGoodXMLResponse), dummyJSONResponse, nil},
 		{"Bad SFX response", makeFakeHTTPResponse(dummyBadXMLResponse), "", errors.New("XML syntax error on line 2: unexpected EOF")},
-		{"Error SFX response", makeFakeHTTPResponse(dummyErrorXMLResponse), "", errors.New(fmt.Sprintf("could not identify context object in response XML: %s", dummyErrorXMLResponse))},
+		{"Error SFX response", makeFakeHTTPResponse(dummyErrorXMLResponse), "", errors.New(fmt.Sprintf("Could not identify context object in response XML: %s", dummyErrorXMLResponse))},
 	}
 
 	for _, testCase := range testCases {

--- a/backend/sfx/response_test.go
+++ b/backend/sfx/response_test.go
@@ -61,7 +61,7 @@ func TestNewSFXResponse(t *testing.T) {
 	}{
 		{"Good SFX response", makeFakeHTTPResponse(dummyGoodXMLResponse), dummyJSONResponse, nil},
 		{"Bad SFX response", makeFakeHTTPResponse(dummyBadXMLResponse), "", errors.New("XML syntax error on line 2: unexpected EOF")},
-		{"Error SFX response", makeFakeHTTPResponse(dummyErrorXMLResponse), "", errors.New("could not identify context object in response")},
+		{"Error SFX response", makeFakeHTTPResponse(dummyErrorXMLResponse), "", errors.New(fmt.Sprintf("could not identify context object in response XML: %s", dummyErrorXMLResponse))},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
* Capitalize first letter of error messages (in part to make it clear in Kibana logs that the entire error message was captured from beginning to end)
* Add SFX response to error message for `nil` `xmlResponseBody.ContextObject` 